### PR TITLE
Implement choice of cloning method

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -27,6 +27,7 @@ Text::Balanced = 0
 -relationship = recommends
 Chemistry::InternalCoords = 0
 Chemistry::Isotope = 0
+Clone = 0
 Compress::Zlib = 0
 
 [Prereqs / Test]

--- a/dist.ini
+++ b/dist.ini
@@ -32,4 +32,5 @@ Compress::Zlib = 0
 
 [Prereqs / Test]
 -phase = test
+Clone = 0
 Test::Simple = 0

--- a/lib/Chemistry/Mol.pm
+++ b/lib/Chemistry/Mol.pm
@@ -40,6 +40,7 @@ use Chemistry::Atom;
 use Chemistry::Bond;
 use Carp;
 use base qw(Chemistry::Obj Exporter);
+use Clone;
 use Storable 'dclone';
 
 our @EXPORT_OK = qw(read_mol);
@@ -48,7 +49,7 @@ our %EXPORT_TAGS = (
       all  => [@EXPORT, @EXPORT_OK],
 );
 
-
+our $clone_backend = 'Storable';
 
 my %FILE_FORMATS = ();
 
@@ -735,8 +736,15 @@ has a pointer to the rest of the universe, the entire universe will be cloned!
 
 sub clone {
     my ($self) = @_;
-    my $clone = dclone $self;
-    $clone->_weaken if Storable->VERSION < 2.14;
+    my $clone;
+    if ($clone_backend eq "Storable") {
+        $clone = dclone $self;
+        $clone->_weaken if Storable->VERSION < 2.14;
+    } elsif ($clone_backend eq "Clone") {
+        $clone = Clone::clone $self;
+    } else {
+        croak "Unknown clone backend '$clone_backend'";
+    }
     $clone;
 }
 

--- a/t/graph.t
+++ b/t/graph.t
@@ -7,7 +7,7 @@ use strict;
 use warnings;
 
 #plan 'no_plan';
-plan tests => 11;
+plan tests => 12;
 
 use Chemistry::File::Dumper;
 
@@ -15,8 +15,11 @@ my $mol = Chemistry::Mol->read("t/mol.pl");
 $mol->bonds(7)->delete;
 
 # clone test
-my $mol2 = $mol->clone;
-is_deeply( $mol, $mol2, "clone" );
+for my $backend ('Clone', 'Storable') {
+    $Chemistry::Mol::clone_backend = $backend;
+    my $mol2 = $mol->clone;
+    is_deeply( $mol, $mol2, "clone by $backend" );
+}
 
 # separate test
 my @mols = $mol->separate;


### PR DESCRIPTION
Some time ago I have stumbled into max. recursion depth limit when cloning Chemistry::Mol molecules ([RT#134852](https://rt.cpan.org/Ticket/Display.html?id=134852)). My proposal to fix this issue is to replace `Storable::dclone()` with `Clone::clone()` as per POD of `Storable`:
> There is a Clone module available on CPAN which implements deep cloning natively, i.e. without freezing to memory and thawing the result. It is aimed to replace Storable's dclone() some day. However, it does not currently support Storable hooks to redefine the way deep cloning is performed.

I do not feel that confident to outright replace the modules, thus my suggestion is to let the user choose which clone backend they want to use. Thus in this PR I propose introducing a variable to choose the backend between `Storable` and `Clone`, the first being the default.